### PR TITLE
Fix detection of posix arithmetic (int or float) types

### DIFF
--- a/posix-types/src/generator/gen_constants_c.ml
+++ b/posix-types/src/generator/gen_constants_c.ml
@@ -9,7 +9,7 @@ module Constants = Posix_base.Generators.Types (struct
            Printf.sprintf
              "\n\
               #define %s_SIZE sizeof(%s)\n\
-              #define IS_%s_FLOAT ((float)((%s)1.23) == 1.23)" name t name t)
+              #define IS_%s_FLOAT ((float)((%s)1.23f) == 1.23f)" name t name t)
          Posix_types_constants.number_types
       @ List.map
           (fun t ->


### PR DESCRIPTION
This warning is generated by clang 14.

> warning: floating-point comparison is always false; constant cannot be represented exactly in type float [-Wliteral-range]

Use float instead of double constants.

```c
#include <stdio.h>

typedef float x;
typedef double y;
typedef int z;

#define IS_FLOAT_FLOAT ((float)((x)1.23) == 1.23) // warning, 0, incorrect!
#define IS_FLOAT_FLOAT_F ((float)((x)1.23f) == 1.23f) // 1
#define IS_DOUBLE_FLOAT ((float)((y)1.23) == 1.23) // warning, 0
#define IS_DOUBLE_FLOAT_F ((float)((y)1.23f) == 1.23f) // 1
#define IS_INT_FLOAT ((float)((z)1.23) == 1.23) // warning, 0
#define IS_INT_FLOAT_F ((float)((z)1.23f) == 1.23f) // 0

int main(void) {
printf("IS_FLOAT_FLOAT: %d\nIS_FLOAT_FLOAT_F: %d\nIS_DOUBLE_FLOAT: %d\n"
       "IS_DOUBLE_FLOAT_F: %d\nIS_INT_FLOAT: %d\nIS_INT_FLOAT_F: %d\n",
       IS_FLOAT_FLOAT, IS_FLOAT_FLOAT_F, IS_DOUBLE_FLOAT, IS_DOUBLE_FLOAT_F,
       IS_INT_FLOAT, IS_INT_FLOAT_F);
}
```