### PR TITLE
Fix ai_family field type of struct addrinfo

### DIFF
--- a/posix-socket/src/posix_socket.mli
+++ b/posix-socket/src/posix_socket.mli
@@ -71,7 +71,7 @@ module Addrinfo : sig
 
   val t : t structure typ
   val ai_flags : (int, t structure) field
-  val ai_family : (sa_family_t, t structure) field
+  val ai_family : (int, t structure) field
   val ai_socktype : (socket_type, t structure) field
   val ai_protocol : (int, t structure) field
   val ai_addrlen : (socklen_t, t structure) field

--- a/posix-socket/src/types/posix_socket_types.ml
+++ b/posix-socket/src/types/posix_socket_types.ml
@@ -50,7 +50,7 @@ module Def (S : Cstubs.Types.TYPE) = struct
 
     let t = S.structure "addrinfo"
     let ai_flags = S.field t "ai_flags" S.int
-    let ai_family = S.field t "ai_family" sa_family_t
+    let ai_family = S.field t "ai_family" S.int
     let ai_socktype = S.field t "ai_socktype" S.int
     let ai_protocol = S.field t "ai_protocol" S.int
     let ai_addrlen = S.field t "ai_addrlen" socklen_t

--- a/posix-socket/src/types/posix_socket_types.mli
+++ b/posix-socket/src/types/posix_socket_types.mli
@@ -48,7 +48,7 @@ module Def (S : Cstubs.Types.TYPE) : sig
 
     val t : t structure S.typ
     val ai_flags : (int, t structure) S.field
-    val ai_family : (sa_family_t, t structure) S.field
+    val ai_family : (int, t structure) S.field
     val ai_socktype : (int, t structure) S.field
     val ai_protocol : (int, t structure) S.field
     val ai_addrlen : (socklen_t, t structure) S.field


### PR DESCRIPTION
This type is int, as per getaddrinfo(3). Using the shorter type sa_family_t happens to work on little-endian architectures, but does not on big-endian ones.

Bug: https://github.com/savonet/ocaml-posix/issues/16