### PR TITLE
Replace ocaml-process by lwt dependency in test

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -110,7 +110,7 @@
  (depends
   dune-configurator
   (ounit2 :with-test)
-  (process :with-test)
+  (lwt :with-test)
   (posix-uname (and :with-test (= :version)))
   ctypes
   (posix-base (= :version))

--- a/opam/posix-getopt.opam
+++ b/opam/posix-getopt.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "3.20"}
   "dune-configurator"
   "ounit2" {with-test}
-  "process" {with-test}
+  "lwt" {with-test}
   "posix-uname" {with-test & = version}
   "ctypes"
   "posix-base" {= version}

--- a/posix-getopt/test/dune
+++ b/posix-getopt/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries process posix-uname posix-getopt ounit2))
+ (libraries lwt.unix posix-uname posix-getopt ounit2))
 
 (rule
  (alias citest)

--- a/posix-getopt/test/test.ml
+++ b/posix-getopt/test/test.ml
@@ -3,6 +3,12 @@ open Posix_getopt
 
 let sysname = Posix_uname.((uname ()).sysname)
 
+module Process = struct
+  let read_stdout cmd args =
+    let cmd = (cmd, Array.append [| cmd |] args) in
+    Lwt_process.pread_lines cmd |> Lwt_stream.to_list |> Lwt_main.run
+end
+
 let is_alpine =
   try
     Process.read_stdout "/bin/sh"


### PR DESCRIPTION
ocaml-process is unmaintained and doesn't work out of the box on bytecode architectures, see:

  https://github.com/dsheets/ocaml-process/pull/10