### PR TITLE
Tolerate name resolution failure in test

### DIFF
--- a/posix-socket/test/test.ml
+++ b/posix-socket/test/test.ml
@@ -23,6 +23,7 @@ let () =
 
 let () =
   match getaddrinfo "google.com" with
+    | exception Posix_socket.Error `AGAIN -> ()
     | sockaddr :: _ ->
         let name, port = getnameinfo sockaddr in
         Printf.printf "Socket name: %s, port: %d\n%!" name port


### PR DESCRIPTION
This can happen in some network-restricted environments (e.g. Debian package build).